### PR TITLE
fix(CanvasForm): Add missing `ref` into CustomLongTextField

### DIFF
--- a/packages/ui/src/components/Form/CustomAutoField.tsx
+++ b/packages/ui/src/components/Form/CustomAutoField.tsx
@@ -12,7 +12,7 @@ import { PropertiesField } from './properties/PropertiesField';
 import { CustomLongTextField } from './customField/CustomLongTextField';
 
 // Name of the properties that should load CustomLongTextField
-const CustomLongTextProps = ['Expression', 'Sasl Jaas Config'];
+const CustomLongTextProps = ['Expression', 'Description'];
 
 /**
  * Custom AutoField that supports all the fields from Uniforms PatternFly

--- a/packages/ui/src/components/Form/CustomAutoForm.tsx
+++ b/packages/ui/src/components/Form/CustomAutoForm.tsx
@@ -61,13 +61,13 @@ export const CustomAutoForm = forwardRef<CustomAutoFormRef, CustomAutoFormProps>
       >
         {props.sortFields ? (
           // For some forms, sorting its fields might be beneficial
-          sortedFieldsNames.map((field) => (
+          sortedFieldsNames.map((field, index) => (
             <AutoField
               key={field}
               name={field}
-              // inputRef={(node: HTMLElement) => {
-              //   fieldsRefs.current[index] = node;
-              // }}
+              inputRef={(node: HTMLElement) => {
+                fieldsRefs.current[index] = node;
+              }}
             />
           ))
         ) : (

--- a/packages/ui/src/components/Form/customField/CustomLongTextField.tsx
+++ b/packages/ui/src/components/Form/customField/CustomLongTextField.tsx
@@ -1,9 +1,11 @@
-import { HTMLFieldProps } from 'uniforms';
 import { LongTextField } from '@kaoto-next/uniforms-patternfly';
+import { FunctionComponent, RefObject } from 'react';
 import './CustomLongTextField.scss';
 
-export type CustomLongTextFieldProps = HTMLFieldProps<string, HTMLDivElement>;
+type LongTextFieldProps = Parameters<typeof LongTextField>[0] & { ref: RefObject<HTMLTextAreaElement> };
 
-export const CustomLongTextField = (props: CustomLongTextFieldProps) => {
-  return <LongTextField className="custom-long-test-field" {...props} rows={1} autoResize={true} />;
+export const CustomLongTextField: FunctionComponent<LongTextFieldProps> = (props) => {
+  return (
+    <LongTextField className="custom-long-test-field" {...props} inputRef={props.ref} rows={1} autoResize={true} />
+  );
 };


### PR DESCRIPTION
### Context
Patternfly's `TextArea` component requires using a `ref` to provide automatic height.

Unfortunately, with React function components, `ref` is not directly possible, so a workaround is needed.

### Changes
This commit restores the commented lines and also adds the missing `ref` object.

relates: https://github.com/KaotoIO/kaoto/issues/1043